### PR TITLE
update interp-tests & compiler-tests function signature

### DIFF
--- a/book.tex
+++ b/book.tex
@@ -6691,11 +6691,12 @@ The \key{map2} function ...
 \subsection{Testing}
 
 The \key{interp-tests} function takes a compiler name (a string), a
-description of the passes, an interpreter for the source language, a
-test family name (a string), and a list of test numbers, and runs the
-compiler passes and the interpreters to check whether the passes
-correct. The description of the passes is a list with one entry per
-pass.  An entry is a list with three things: a string giving the name
+typechecker (see the comment for check-passes), a description of the
+passes, an interpreter for the source language, a test family name
+(a string), and a list of test numbers, and runs the compiler passes
+and the interpreters to check whether the passes correct.
+The description of the passes is a list with one entry per pass.
+An entry is a list with three things: a string giving the name
 of the pass, the function that implements the pass (a translator from
 AST to AST), and a function that implements the interpreter (a
 function from AST to result value) for the language of the output of
@@ -6707,17 +6708,18 @@ test number, ending in \key{.scm}. Also, for each Scheme program there
 is a file with the same number except that it ends with \key{.in} that
 provides the input for the Scheme program.
 \begin{lstlisting}
-(define (interp-tests name passes test-family test-nums) ...
+(define (interp-tests name typechecker passes test-family test-nums) ...
 \end{lstlisting}
 
-The compiler-tests function takes a compiler name (a string) a
-description of the passes (see the comment for \key{interp-tests}) a
-test family name (a string), and a list of test numbers (see the
-comment for interp-tests), and runs the compiler to generate x86 (a
-\key{.s} file) and then runs gcc to generate machine code.  It runs
-the machine code and checks that the output is 42.
+The compiler-tests function takes a compiler name (a string), a
+typechecker (see the comment for check-passes) a description of
+the passes (ditto), a description of the passes (see the comment for
+\key{interp-tests}), a test family name (a string), and a list of
+test numbers (see the comment for interp-tests), and runs the compiler
+to generate x86 (a \key{.s} file) and then runs gcc to generate
+machine code.  It runs the machine code and checks that the output is 42.
 \begin{lstlisting}
-(define (compiler-tests name passes test-family test-nums) ...)
+(define (compiler-tests name typechecker passes test-family test-nums) ...)
 \end{lstlisting}
 
 The compile-file function takes a description of the compiler passes

--- a/book.tex
+++ b/book.tex
@@ -512,7 +512,7 @@ The pattern is not the same thing as a quasiquote expression used to
 \emph{construct} ASTs, however, the similarity is intentional: constructing and
 deconstructing ASTs uses similar syntax.
 %
-While the pattern uses a restricted syntax, 
+While the pattern uses a restricted syntax,
 the body of the match clause may contain any Racket code whatsoever.
 
 
@@ -584,9 +584,9 @@ defined by structural recursion.
       [`(read) #t]
       [`(- ,e) (exp? e)]
       [`(+ ,e1 ,e2)
-       (and (exp? e1) (exp? e2))]))  
+       (and (exp? e1) (exp? e2))]))
   (match sexp
-    [`(program ,e) (exp? e)]    
+    [`(program ,e) (exp? e)]
     [else #f]))
 
 (R0? `(+ (read) (- 8)))
@@ -598,7 +598,7 @@ defined by structural recursion.
 \begin{lstlisting}
 
 
-  
+
 
 
 
@@ -659,7 +659,7 @@ an interpreter for the $R_0$ language, which will also serve as a
 second example of structural recursion. The \texttt{interp-R0}
 function is defined in Figure~\ref{fig:interp-R0}. The body of the
 function is a match on the input program \texttt{p} and
-then a call to the \lstinline{exp} helper function, which in turn has 
+then a call to the \lstinline{exp} helper function, which in turn has
 one match clause per grammar rule for $R_0$ expressions.
 
 The \lstinline{exp} function is naturally recursive: clauses for internal AST
@@ -1268,7 +1268,7 @@ auxiliary data from one step of the compiler to the next. )
              (\key{subq} \; \Arg\; \Arg) \mid
              (\key{movq} \; \Arg\; \Arg) \mid
              (\key{retq})\\
-      &\mid& (\key{negq} \; \Arg) \mid 
+      &\mid& (\key{negq} \; \Arg) \mid
              (\key{callq} \; \mathit{label}) \mid
              (\key{pushq}\;\Arg) \mid
              (\key{popq}\;\Arg) \\
@@ -4912,7 +4912,7 @@ needs to be followed. Thus, we zero-out all locations on the root
 stack in the prelude of \code{main}. In
 Figure~\ref{fig:print-x86-output-gc}, the instruction
 %
-\lstinline{movq $0, (%r15)} 
+\lstinline{movq $0, (%r15)}
 %
 accomplishes this task. The garbage collector tests each root to see
 if it is null prior to dereferencing it.


### PR DESCRIPTION
Hi professor:

I find the `interp-tests` and `compiler-tests` in Appendix Section is out of date.
The new-version code you provided in https://github.com/IUCompilerCourse/support-code-for-students accept one more arguments (typechecker). 

BTW, my editor will remove trailing space automatically, so the first commit just for that.
I think that can help tidy up the code a little bit.

Chung Yen